### PR TITLE
Add last-commit badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,275 +79,276 @@ in your favourite language.*
 
 *Solutions to AoC in C.*
 
-* [krokerik/Advent-of-Code/](https://github.com/krokerik/Advent-of-Code/tree/master/2018/c)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/krokerik/Advent-of-Code.svg) [krokerik/Advent-of-Code/](https://github.com/krokerik/Advent-of-Code/tree/master/2018/c)
 
 #### C#
 
 *Solutions to AoC in C#.*
 
-* [encse/adventofcode](https://github.com/encse/adventofcode)
-* [myquay/AOC2018](https://github.com/myquay/AOC2018)
-* [schoradt/adventofcode2018](https://github.com/schoradt/adventofcode2018)
-* [tomwallace/AdventOfCode2018](https://github.com/tomwallace/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/encse/adventofcode.svg) [encse/adventofcode](https://github.com/encse/adventofcode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/myquay/AOC2018.svg) [myquay/AOC2018](https://github.com/myquay/AOC2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/schoradt/adventofcode2018.svg) [schoradt/adventofcode2018](https://github.com/schoradt/adventofcode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/tomwallace/AdventOfCode2018.svg) [tomwallace/AdventOfCode2018](https://github.com/tomwallace/AdventOfCode2018)
 
 #### C++
 
 *Solutions to AoC in C++.*
 
-* [132ikl/advent-of-code-2018](https://github.com/132ikl/advent-of-code-2018)
-* [Chrinkus/advent-of-code-2018](https://github.com/Chrinkus/advent-of-code-2018)
-* [LukeMoll/adventofcode2018](https://github.com/LukeMoll/adventofcode2018)
-* [MarkRDavison/AdventOfCode2018](https://github.com/MarkRDavison/AdventOfCode2018)
-* [metinsuloglu/AdventofCode18](https://github.com/metinsuloglu/AdventofCode18)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/132ikl/advent-of-code-2018.svg) [132ikl/advent-of-code-2018](https://github.com/132ikl/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/Chrinkus/advent-of-code-2018.svg) [Chrinkus/advent-of-code-2018](https://github.com/Chrinkus/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/LukeMoll/adventofcode2018.svg) [LukeMoll/adventofcode2018](https://github.com/LukeMoll/adventofcode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/MarkRDavison/AdventOfCode2018.svg) [MarkRDavison/AdventOfCode2018](https://github.com/MarkRDavison/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/metinsuloglu/AdventofCode18.svg) [metinsuloglu/AdventofCode18](https://github.com/metinsuloglu/AdventofCode18)
 
 #### Clojure
 
 *Solutions to AoC in Clojure.*
 
-* [adventofcode-clojurians/adventofcode-clojurians](https://github.com/adventofcode-clojurians/adventofcode-clojurians)
-* [borkdude/advent-of-cljc](https://github.com/borkdude/advent-of-cljc) - Cross-platform Clojure(script) solutions
+* ![GitHub last commit](https://img.shields.io/github/last-commit/adventofcode-clojurians/adventofcode-clojurians.svg) [adventofcode-clojurians/adventofcode-clojurians](https://github.com/adventofcode-clojurians/adventofcode-clojurians)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/borkdude/advent-of-cljc.svg) [borkdude/advent-of-cljc](https://github.com/borkdude/advent-of-cljc) - Cross-platform Clojure(script) solutions
 
 #### Dart
 
 *Solutions to AoC in Dart.*
 
-* [code-shoily/advent-of-dart](https://github.com/code-shoily/advent-of-dart)
-* [julemand101/AdventOfCode2018](https://github.com/julemand101/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/code-shoily/advent-of-dart.svg) [code-shoily/advent-of-dart](https://github.com/code-shoily/advent-of-dart)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/julemand101/AdventOfCode2018.svg) [julemand101/AdventOfCode2018](https://github.com/julemand101/AdventOfCode2018)
 
 #### Elixir
 
 *Solutions to AoC in Elixir.*
 
-* [axsuul/advent-of-code](https://github.com/axsuul/advent-of-code)
-* [codybartfast/aoc18](https://github.com/codybartfast/aoc18)
-* [kw7oe/advent-of-code-2018](https://github.com/kw7oe/advent-of-code-2018)
-* [scmx/advent-of-code-2018-elixir](https://github.com/scmx/advent-of-code-2018-elixir)
-* [seanhandley/adventofcode2018](https://github.com/seanhandley/adventofcode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/axsuul/advent-of-code.svg) [axsuul/advent-of-code](https://github.com/axsuul/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/codybartfast/aoc18.svg) [codybartfast/aoc18](https://github.com/codybartfast/aoc18)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/kw7oe/advent-of-code-2018.svg) [kw7oe/advent-of-code-2018](https://github.com/kw7oe/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/scmx/advent-of-code-2018-elixir.svg) [scmx/advent-of-code-2018-elixir](https://github.com/scmx/advent-of-code-2018-elixir)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/seanhandley/adventofcode2018.svg) [seanhandley/adventofcode2018](https://github.com/seanhandley/adventofcode2018)
 
 #### Elm
 
 *Solutions to AoC in Elm and Literate Elm.*
 
-* [Janiczek/advent-of-code](https://github.com/Janiczek/advent-of-code)
-* [jwoLondon/adventOfCode](https://github.com/jwoLondon/adventOfCode/)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/Janiczek/advent-of-code.svg) [Janiczek/advent-of-code](https://github.com/Janiczek/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/jwoLondon/adventOfCode.svg) [jwoLondon/adventOfCode](https://github.com/jwoLondon/adventOfCode)
 
 #### F#
 
 *Solutions to AoC in F#.*
 
-* [CameronAavik/AdventOfCode](https://github.com/CameronAavik/AdventOfCode)
-* [andreasjhkarlsson/aoc-2018](https://github.com/andreasjhkarlsson/aoc-2018)
-* [ryepup/advent-of-code](https://github.com/ryepup/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/CameronAavik/AdventOfCode.svg) [CameronAavik/AdventOfCode](https://github.com/CameronAavik/AdventOfCode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/andreasjhkarlsson/aoc-2018.svg) [andreasjhkarlsson/aoc-2018](https://github.com/andreasjhkarlsson/aoc-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/ryepup/advent-of-code.svg) [ryepup/advent-of-code](https://github.com/ryepup/advent-of-code)
 
 #### Go
 
 *Solutions to AoC in Go.*
 
-* [atssteve/advent_of_code_2018/](https://github.com/atssteve/advent_of_code_2018)
-* [dandua98/AdventOfCode2018](https://github.com/dandua98/AdventOfCode2018)
-* [feffes/adventofcode2018](https://github.com/feffes/adventofcode2018)
-* [feiss/aoc2018](https://github.com/feiss/aoc2018)
-* [fesh0r/adventofcode](https://github.com/fesh0r/adventofcode)
-* [fvm/super-duper-barnacle-AoC-2018](https://github.com/fvm/super-duper-barnacle-AoC-2018)
-* [kindermoumoute/adventofcode](https://github.com/kindermoumoute/adventofcode)
-* [mauricioabreu/AdventOfCode2018](https://github.com/mauricioabreu/AdventOfCode2018)
-* [tpaschalis/Golang-Practice/AdventOfCode2018](https://github.com/tpaschalis/Golang-practice/tree/master/AdventOfCode2018)
-* [wilbertom/advent-of-code-2018/](https://github.com/wilbertom/advent-of-code-2018/)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/atssteve/advent_of_code_2018.svg) [atssteve/advent_of_code_2018/](https://github.com/atssteve/advent_of_code_2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/dandua98/AdventOfCode2018.svg) [dandua98/AdventOfCode2018](https://github.com/dandua98/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/feffes/adventofcode2018.svg) [feffes/adventofcode2018](https://github.com/feffes/adventofcode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/feiss/aoc2018.svg) [feiss/aoc2018](https://github.com/feiss/aoc2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/fesh0r/adventofcode.svg) [fesh0r/adventofcode](https://github.com/fesh0r/adventofcode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/fvm/super-duper-barnacle-AoC-2018.svg) [fvm/super-duper-barnacle-AoC-2018](https://github.com/fvm/super-duper-barnacle-AoC-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/kindermoumoute/adventofcode.svg) [kindermoumoute/adventofcode](https://github.com/kindermoumoute/adventofcode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/mauricioabreu/AdventOfCode2018.svg) [mauricioabreu/AdventOfCode2018](https://github.com/mauricioabreu/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/tpaschalis/Golang-practice.svg) [tpaschalis/Golang-Practice/AdventOfCode2018](https://github.com/tpaschalis/Golang-practice/tree/master/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/wilbertom/advent-of-code-2018.svg) [wilbertom/advent-of-code-2018/](https://github.com/wilbertom/advent-of-code-2018)
 
 #### Groovy
 
 *Solutions to AoC in Groovy.*
 
-* [deroffal/AoC_2018](https://github.com/deroffal/AoC_2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/deroffal/AoC_2018.svg) [deroffal/AoC_2018](https://github.com/deroffal/AoC_2018)
 
 #### Haskell
 
 *Solutions to AoC in Haskell.*
 
-* [glguy/advent2018](https://github.com/glguy/advent2018)
-* [mstksg/advent-of-code-2018](https://github.com/mstksg/advent-of-code-2018)
-* [nerdopoly/aoc-2018](https://github.com/nerdopoly/aoc-2018)
-* [tfausak/advent-of-code](https://github.com/tfausak/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/glguy/advent2018.svg) [glguy/advent2018](https://github.com/glguy/advent2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/mstksg/advent-of-code-2018.svg) [mstksg/advent-of-code-2018](https://github.com/mstksg/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/nerdopoly/aoc-2018.svg) [nerdopoly/aoc-2018](https://github.com/nerdopoly/aoc-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/tfausak/advent-of-code.svg) [tfausak/advent-of-code](https://github.com/tfausak/advent-of-code)
 
 #### Java
 
 *Solutions to AoC in Java.*
 
-* [AnwarAfaq/AdventOfCode](https://github.com/AnwarAfaq/AdventOfCode)
-* [ars216/Advent-of-Code-2018](https://github.com/ars216/Advent-of-Code-2018)
-* [jeffrosenberg/advent-of-code-2018](https://github.com/jeffrosenberg/advent-of-code-2018)
-* [joethei/Advent-of-Code-2018](https://github.com/joethei/Advent-of-Code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/AnwarAfaq/AdventOfCode.svg) [AnwarAfaq/AdventOfCode](https://github.com/AnwarAfaq/AdventOfCode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/ars216/Advent-of-Code-2018.svg) [ars216/Advent-of-Code-2018](https://github.com/ars216/Advent-of-Code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/jeffrosenberg/advent-of-code-2018.svg) [jeffrosenberg/advent-of-code-2018](https://github.com/jeffrosenberg/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/joethei/Advent-of-Code-2018.svg) [joethei/Advent-of-Code-2018](https://github.com/joethei/Advent-of-Code-2018)
 
 #### JavaScript
 
 *Solutions to AoC in JavaScript.*
 
-* [Covicake/AdventOfCode](https://github.com/Covicake/AdventOfCode)
-* [SeanECogan/advent-of-code-2018](https://github.com/SeanECogan/advent-of-code-2018)
-* [TolleyB-J/AdventOfCode2018](https://github.com/TolleyB-J/AdventOfCode2018)
-* [adriennetacke/advent-of-code-2018](https://github.com/adriennetacke/advent-of-code-2018)
-* [anubhavsrivastava/advent-of-code-js-2018](https://github.com/anubhavsrivastava/advent-of-code-js-2018)
-* [arnaskro/advent-of-code-2018](https://github.com/arnaskro/advent-of-code-2018)
-* [chinesedfan/adventofcode](https://github.com/chinesedfan/adventofcode)
-* [dxnter/advent-of-code-2018](https://github.com/dxnter/advent-of-code-2018)
-* [luna1nd1go/aoc-2018](https://github.com/luna1nd1go/aoc-2018)
-* [mariotacke/advent-of-code-2018](https://github.com/mariotacke/advent-of-code-2018)
-* [pizzafox/aoc-2018](https://github.com/pizzafox/aoc-2018)
-* [roebuk/advent-of-code](https://github.com/roebuk/advent-of-code/)
-* [rovaniemi/advent-of-code-2018](https://github.com/rovaniemi/advent-of-code-2018)
-* [sguest/advent-of-code](https://github.com/sguest/advent-of-code)
-* [spalberg/AdventOfCode](https://github.com/spalberg/AdventOfCode)
-* [Allypost/advent-of-code-2018](https://github.com/Allypost/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/Covicake/AdventOfCode.svg) [Covicake/AdventOfCode](https://github.com/Covicake/AdventOfCode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/SeanECogan/advent-of-code-2018.svg) [SeanECogan/advent-of-code-2018](https://github.com/SeanECogan/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/TolleyB-J/AdventOfCode2018.svg) [TolleyB-J/AdventOfCode2018](https://github.com/TolleyB-J/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/adriennetacke/advent-of-code-2018.svg) [adriennetacke/advent-of-code-2018](https://github.com/adriennetacke/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/anubhavsrivastava/advent-of-code-js-2018.svg) [anubhavsrivastava/advent-of-code-js-2018](https://github.com/anubhavsrivastava/advent-of-code-js-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/arnaskro/advent-of-code-2018.svg) [arnaskro/advent-of-code-2018](https://github.com/arnaskro/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/chinesedfan/adventofcode.svg) [chinesedfan/adventofcode](https://github.com/chinesedfan/adventofcode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/dxnter/advent-of-code-2018.svg) [dxnter/advent-of-code-2018](https://github.com/dxnter/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/luna1nd1go/aoc-2018.svg) [luna1nd1go/aoc-2018](https://github.com/luna1nd1go/aoc-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/mariotacke/advent-of-code-2018.svg) [mariotacke/advent-of-code-2018](https://github.com/mariotacke/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/pizzafox/aoc-2018.svg) [pizzafox/aoc-2018](https://github.com/pizzafox/aoc-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/roebuk/advent-of-code.svg) [roebuk/advent-of-code](https://github.com/roebuk/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/rovaniemi/advent-of-code-2018.svg) [rovaniemi/advent-of-code-2018](https://github.com/rovaniemi/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/sguest/advent-of-code.svg) [sguest/advent-of-code](https://github.com/sguest/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/spalberg/AdventOfCode.svg) [spalberg/AdventOfCode](https://github.com/spalberg/AdventOfCode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/Allypost/advent-of-code-2018.svg) [Allypost/advent-of-code-2018](https://github.com/Allypost/advent-of-code-2018)
 
 #### Kotlin
 
 *Solutions to AoC in Kotlin.*
 
-* [AsmPrgmC3/AoC2018](https://github.com/AsmPrgmC3/AoC2018)
-* [Yolgie/AdventOfCode2018](https://github.com/Yolgie/AdventOfCode2018)
-* [edgars-supe/advent-of-code](https://github.com/edgars-supe/advent-of-code)
-* [fdlk/advent-2018](https://github.com/fdlk/advent-2018)
-* [hughjdavey/aoc-2018](https://github.com/hughjdavey/aoc-2018)
-* [loehnertz/advent-of-code-2018](https://github.com/loehnertz/advent-of-code-2018)
-* [tginsberg/advent-2018-kotlin](https://github.com/tginsberg/advent-2018-kotlin)
-* [wakingrufus/advent-of-code-2018](https://github.com/wakingrufus/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/AsmPrgmC3/AoC2018.svg) [AsmPrgmC3/AoC2018](https://github.com/AsmPrgmC3/AoC2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/Yolgie/AdventOfCode2018.svg) [Yolgie/AdventOfCode2018](https://github.com/Yolgie/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/edgars-supe/advent-of-code.svg) [edgars-supe/advent-of-code](https://github.com/edgars-supe/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/fdlk/advent-2018.svg) [fdlk/advent-2018](https://github.com/fdlk/advent-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/hughjdavey/aoc-2018.svg) [hughjdavey/aoc-2018](https://github.com/hughjdavey/aoc-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/loehnertz/advent-of-code-2018.svg) [loehnertz/advent-of-code-2018](https://github.com/loehnertz/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/tginsberg/advent-2018-kotlin.svg) [tginsberg/advent-2018-kotlin](https://github.com/tginsberg/advent-2018-kotlin)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/wakingrufus/advent-of-code-2018.svg) [wakingrufus/advent-of-code-2018](https://github.com/wakingrufus/advent-of-code-2018)
 
 #### Nim
 
 *Solutions to AoC in Nim.*
 
-* [jabbalaci/AdventOfCode2018](https://github.com/jabbalaci/AdventOfCode2018)
-* [narimiran/AdventOfCode2018](https://github.com/narimiran/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/jabbalaci/AdventOfCode2018.svg) [jabbalaci/AdventOfCode2018](https://github.com/jabbalaci/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/narimiran/AdventOfCode2018.svg) [narimiran/AdventOfCode2018](https://github.com/narimiran/AdventOfCode2018)
 
 #### PHP
 
 *Solutions to AoC in PHP.*
 
-* [aran112000/Advent-of-Code-2018](https://github.com/aran112000/Advent-of-Code-2018)
-* [cbzink/AdventOfCode2018](https://github.com/cbzink/AdventOfCode2018)
-* [deanhouseholder/advent-of-code-2018](https://github.com/deanhouseholder/advent-of-code-2018)
-* [zmontgo/advent_of_code](https://github.com/zmontgo/advent_of_code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/aran112000/Advent-of-Code-2018.svg) [aran112000/Advent-of-Code-2018](https://github.com/aran112000/Advent-of-Code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/cbzink/AdventOfCode2018.svg) [cbzink/AdventOfCode2018](https://github.com/cbzink/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/deanhouseholder/advent-of-code-2018.svg) [deanhouseholder/advent-of-code-2018](https://github.com/deanhouseholder/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/zmontgo/advent_of_code.svg) [zmontgo/advent_of_code](https://github.com/zmontgo/advent_of_code)
 
 #### Perl
 
 *Solutions to AoC in Perl.*
 
-* [bewuethr/advent-of-code/2018](https://github.com/bewuethr/advent-of-code/tree/master/2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/bewuethr/advent-of-code.svg) [bewuethr/advent-of-code/2018](https://github.com/bewuethr/advent-of-code/tree/master/2018)
 
 #### Polyglot
 
 *Solutions to AoC in multiple languages.*
 
-* [ephemient/aoc2018](https://github.com/ephemient/aoc2018) (Haskell and Kotlin)
-* [pietroppeter/AdventOfCode2018](https://github.com/pietroppeter/AdventOfCode2018)
-* [stewartpark/aoc-2018](https://github.com/stewartpark/aoc-2018)
-* [vypxl/aoc](https://github.com/vypx/aoc)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/ephemient/aoc2018.svg) [ephemient/aoc2018](https://github.com/ephemient/aoc2018) (Haskell and Kotlin)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/pietroppeter/AdventOfCode2018.svg) [pietroppeter/AdventOfCode2018](https://github.com/pietroppeter/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/stewartpark/aoc-2018.svg) [stewartpark/aoc-2018](https://github.com/stewartpark/aoc-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/vypx/aoc.svg) [vypxl/aoc](https://github.com/vypx/aoc)
 
 #### Pony
 
 *Solutions to AoC in Pony.*
 
-* [kulibali/advent_of_code_2018](https://github.com/kulibali/advent_of_code_2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/kulibali/advent_of_code_2018.svg) [kulibali/advent_of_code_2018](https://github.com/kulibali/advent_of_code_2018)
 
 #### PowerShell
 
 *Solutions to AoC in PowerShell.*
 
-* [SotoDucani/AdventOfCode2018](https://github.com/SotoDucani/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/SotoDucani/AdventOfCode2018.svg) [SotoDucani/AdventOfCode2018](https://github.com/SotoDucani/AdventOfCode2018)
 
 #### Python
 
 *Solutions to AoC in Python.*
 
-* [Kurocon/AdventOfCode2018](https://github.com/Kurocon/AdventOfCode2018)
-* [LinusCDE/AdventOfCode2018](https://github.com/LinusCDE/AdventOfCode2018)
-* [S0Ulle33/Advent-of-Code-2018](https://github.com/S0Ulle33/Advent-of-Code-2018)
-* [ahriley/advent-of-code-2018](https://github.com/ahriley/advent-of-code-2018)
-* [badouralix/advent-of-code-2018](https://github.com/badouralix/advent-of-code-2018)
-* [bookwyrm12/adventofcode2018](https://github.com/bookwyrm12/adventofcode2018)
-* [danong/advent-of-code-2018](https://github.com/danong/advent-of-code-2018)
-* [davidpneal/AdventofCode18](https://github.com/davidpneal/python/tree/master/AdventofCode18)
-* [dstine/aoc](https://github.com/dstine/aoc)
-* [iBelieve/adventofcode](https://github.com/iBelieve/adventofcode)
-* [j0057/aoc2018](https://github.com/j0057/aoc2018)
-* [oskar404/aoc](https://github.com/oskar404/aoc)
-* [rhbvkleef/aoc-2018](https://github.com/rhbvkleef/aoc-2018)
-* [rossengeorgiev/adventofcode-2018](https://github.com/rossengeorgiev/adventofcode-2018/)
-* [stacybrock/advent-of-code](https://github.com/stacybrock/advent-of-code)
-* [sw561/AdventOfCode2018](https://github.com/sw561/AdventOfCode2018)
-* [tobiasvl/adventofcode](https://github.com/tobiasvl/adventofcode)
-* [tterb/advent-of-code](https://github.com/tterb/advent-of-code)
-* [webbiscuit/adventofcode2018](https://github.com/webbiscuit/adventofcode2018)
-* [xaranke/advent_of_code_2k18](https://github.com/xaranke/advent_of_code_2k18)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/Kurocon/AdventOfCode2018.svg) [Kurocon/AdventOfCode2018](https://github.com/Kurocon/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/LinusCDE/AdventOfCode2018.svg) [LinusCDE/AdventOfCode2018](https://github.com/LinusCDE/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/S0Ulle33/Advent-of-Code-2018.svg) [S0Ulle33/Advent-of-Code-2018](https://github.com/S0Ulle33/Advent-of-Code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/ahriley/advent-of-code-2018.svg) [ahriley/advent-of-code-2018](https://github.com/ahriley/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/badouralix/advent-of-code-2018.svg) [badouralix/advent-of-code-2018](https://github.com/badouralix/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/bookwyrm12/adventofcode2018.svg) [bookwyrm12/adventofcode2018](https://github.com/bookwyrm12/adventofcode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/danong/advent-of-code-2018.svg) [danong/advent-of-code-2018](https://github.com/danong/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/davidpneal/python.svg) [davidpneal/AdventofCode18](https://github.com/davidpneal/python/tree/master/AdventofCode18)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/dstine/aoc.svg) [dstine/aoc](https://github.com/dstine/aoc)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/iBelieve/adventofcode.svg) [iBelieve/adventofcode](https://github.com/iBelieve/adventofcode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/j0057/aoc2018.svg) [j0057/aoc2018](https://github.com/j0057/aoc2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/oskar404/aoc.svg) [oskar404/aoc](https://github.com/oskar404/aoc)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/rhbvkleef/aoc-2018.svg) [rhbvkleef/aoc-2018](https://github.com/rhbvkleef/aoc-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/rossengeorgiev/adventofcode-2018.svg) [rossengeorgiev/adventofcode-2018](https://github.com/rossengeorgiev/adventofcode-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/stacybrock/advent-of-code.svg) [stacybrock/advent-of-code](https://github.com/stacybrock/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/sw561/AdventOfCode2018.svg) [sw561/AdventOfCode2018](https://github.com/sw561/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/tobiasvl/adventofcode.svg) [tobiasvl/adventofcode](https://github.com/tobiasvl/adventofcode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/tterb/advent-of-code.svg) [tterb/advent-of-code](https://github.com/tterb/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/webbiscuit/adventofcode2018.svg) [webbiscuit/adventofcode2018](https://github.com/webbiscuit/adventofcode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/xaranke/advent_of_code_2k18.svg) [xaranke/advent_of_code_2k18](https://github.com/xaranke/advent_of_code_2k18)
 
 #### Racket
 
 *Solutions to AoC in Racket.*
 
-* [Bogdanp/racket-aoc-2018](https://github.com/Bogdanp/racket-aoc-2018)
-* [CuriousYogurt/AdventOfCode](https://github.com/curiousyogurt/AdventOfCode)
-* [Saityi/advent-of-code-2018](https://github.com/Saityi/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/Bogdanp/racket-aoc-2018.svg) [Bogdanp/racket-aoc-2018](https://github.com/Bogdanp/racket-aoc-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/curiousyogurt/AdventOfCode.svg) [CuriousYogurt/AdventOfCode](https://github.com/curiousyogurt/AdventOfCode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/Saityi/advent-of-code-2018.svg) [Saityi/advent-of-code-2018](https://github.com/Saityi/advent-of-code-2018)
 
 #### ReasonML
 
 *Solutions to AoC in ReasonML.*
 
-* [believer/advent-of-code-2018](https://github.com/believer/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/believer/advent-of-code-2018.svg) [believer/advent-of-code-2018](https://github.com/believer/advent-of-code-2018)
 
 #### Red
 
 *Solutions to AoC in Red.*
 
-* [lpvm/adventofcode2018](https://github.com/lpvm/adventofcode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/lpvm/adventofcode2018.svg) [lpvm/adventofcode2018](https://github.com/lpvm/adventofcode2018)
 
 #### Ruby
 
 *Solutions to AoC in Ruby.*
 
-* [chemturion/advent-of-code-2018](https://github.com/chemturion/advent-of-code-2018)
-* [dnamsons/Advent-of-Code-2018](https://github.com/dnamsons/Advent-of-Code-2018)
-* [nipinium/aoc18](https://github.com/nipinium/aoc18)
-* [ste001/advent-of-code-2018](https://github.com/ste001/advent-of-code-2018)
-* [taylorthurlow/advent-of-code-2018](https://github.com/taylorthurlow/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/chemturion/advent-of-code-2018.svg) [chemturion/advent-of-code-2018](https://github.com/chemturion/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/dnamsons/Advent-of-Code-2018.svg) [dnamsons/Advent-of-Code-2018](https://github.com/dnamsons/Advent-of-Code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/nipinium/aoc18.svg) [nipinium/aoc18](https://github.com/nipinium/aoc18)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/ste001/advent-of-code-2018.svg) [ste001/advent-of-code-2018](https://github.com/ste001/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/taylorthurlow/advent-of-code-2018.svg) [taylorthurlow/advent-of-code-2018](https://github.com/taylorthurlow/advent-of-code-2018)
 
 #### Rust
 
 *Solutions to AoC in Rust.*
 
 * [(GitLab) BafDyce/adventofcode](https://gitlab.com/BafDyce/adventofcode/tree/2018) (`2018` branch; will be merged into `master` after the event)
-* [Poooel/advent-of-code-2018](https://github.com/Poooel/advent-of-code-2018)
-* [callum-oakley/advent-of-code-2018](https://github.com/callum-oakley/advent-of-code-2018)
-* [foo-jin/advent-of-code](https://github.com/foo-jin/advent-of-code)
-* [iicurtis/Rust-Advent-of-Code-2018](https://github.com/iicurtis/Rust-Advent-of-Code-2018)
-* [k0nserv/advent-of-rust-2018](https://github.com/k0nserv/advent-of-rust-2018)
-* [lazear/adventofcode2018](https://github.com/lazear/adventofcode2018)
-* [maxdeviant/advent-of-code](https://github.com/maxdeviant/advent-of-code)
-* [nwn/Advent-of-Code-2018](https://github.com/nwn/Advent-of-Code-2018)
-* [rceuls/Aoc2018](https://github.com/rceuls/Aoc2018)
-* [ryanhofer/adventofcode2018](https://github.com/ryanhofer/adventofcode2018)
-* [sebnow/adventofcode](https://github.com/sebnow/adventofcode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/Poooel/advent-of-code-2018.svg) [Poooel/advent-of-code-2018](https://github.com/Poooel/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/callum-oakley/advent-of-code-2018.svg) [callum-oakley/advent-of-code-2018](https://github.com/callum-oakley/advent-of-code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/foo-jin/advent-of-code.svg) [foo-jin/advent-of-code](https://github.com/foo-jin/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/iicurtis/Rust-Advent-of-Code-2018.svg) [iicurtis/Rust-Advent-of-Code-2018](https://github.com/iicurtis/Rust-Advent-of-Code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/k0nserv/advent-of-rust-2018.svg) [k0nserv/advent-of-rust-2018](https://github.com/k0nserv/advent-of-rust-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/lazear/adventofcode2018.svg) [lazear/adventofcode2018](https://github.com/lazear/adventofcode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/maxdeviant/advent-of-code.svg) [maxdeviant/advent-of-code](https://github.com/maxdeviant/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/nwn/Advent-of-Code-2018.svg) [nwn/Advent-of-Code-2018](https://github.com/nwn/Advent-of-Code-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/rceuls/Aoc2018.svg) [rceuls/Aoc2018](https://github.com/rceuls/Aoc2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/ryanhofer/adventofcode2018.svg) [ryanhofer/adventofcode2018](https://github.com/ryanhofer/adventofcode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/sebnow/adventofcode.svg) [sebnow/adventofcode](https://github.com/sebnow/adventofcode)
 
 #### Scala
 
 *Solutions to AoC in Scala.*
 
-* [FichteFoll/advent-of-code](https://github.com/FichteFoll/advent-of-code)
-* [FlorianCassayre/AdventOfCode-2018](https://github.com/FlorianCassayre/AdventOfCode-2018)
-* [nbardiuk/adventofcode](https://github.com/nbardiuk/adventofcode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/FichteFoll/advent-of-code.svg) [FichteFoll/advent-of-code](https://github.com/FichteFoll/advent-of-code)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/FlorianCassayre/AdventOfCode-2018.svg) [FlorianCassayre/AdventOfCode-2018](https://github.com/FlorianCassayre/AdventOfCode-2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/nbardiuk/adventofcode.svg) [nbardiuk/adventofcode](https://github.com/nbardiuk/adventofcode)
 
 #### Swift
 
 *Solutions to AoC in Swift.*
 
-* [HarshilShah/AdventOfCode](https://github.com/HarshilShah/AdventOfCode)
-* [Levivig/AdventOfCode2018](https://github.com/Levivig/AdventOfCode2018)
-* [davedelong/AOC](https://github.com/davedelong/AOC)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/HarshilShah/AdventOfCode.svg) [HarshilShah/AdventOfCode](https://github.com/HarshilShah/AdventOfCode)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/Levivig/AdventOfCode2018.svg) [Levivig/AdventOfCode2018](https://github.com/Levivig/AdventOfCode2018)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/davedelong/AOC.svg) [davedelong/AOC](https://github.com/davedelong/AOC)
 
 #### Zig
 
 *Solutions to AoC in Zig.*
 
-* [meheleventyone/aoc-2018-zig](https://github.com/meheleventyone/aoc-2018-zig)
+* ![GitHub last commit](https://img.shields.io/github/last-commit/meheleventyone/aoc-2018-zig.svg) [meheleventyone/aoc-2018-zig](https://github.com/meheleventyone/aoc-2018-zig)
+
 
 ### Live Streams
 


### PR DESCRIPTION
Closed #56. Update section solutions with a simple script.
```
    lines.forEach((l) => {
        console.log(l.replace(/\* (\[.+\]\(https:\/\/github.com\/(.+)\))/, (match, rest, repo) => {
            return `* ![GitHub last commit](https://img.shields.io/github/last-commit/${repo}.svg) ${rest}`;
        }));
    });
```

And fix special ones manually, which include,
- end with a slash
- contain detailed path to a folder
- other websites, i.e. Gitlab

You can have a preview here, https://github.com/chinesedfan/awesome-advent-of-code/tree/patch-2, and find lots of things interesting,
- most of authors updated today, while some were yesterday
- some were renamed or 404 not found
- even one last committed at Jan

Sometimes partial badges are failed to be loaded. It's normal and please refresh. Enjoy!