### PR TITLE
Added phikal/aoc2018 (awk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a collection of awesome resources related to the yearly
 * [Other Advent Calendars](#other-advent-calendars)
 * [2018](#2018)
   * [Solutions](#solutions)
+    * [AWK](#awk)
     * [C](#c)
     * [C#](#c-1)
     * [C++](#c-2)
@@ -74,6 +75,12 @@ in your favourite language.*
 **WARNING:** All of these likely contain spoilers.
 
 ### Solutions
+
+#### AWK
+
+*Solutions to AoC in AWK.*
+
+* [phikal/aoc2018](https://github.com/phikal/aoc2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/phikal/aoc2018.svg)
 
 #### C
 


### PR DESCRIPTION
There's not a lot to say by per se, I'd just like to remark that using f-strings in the badge-script was a bit annoying, since people like me who run debian stable (with python3.4) have can't use the script. Unless it's really necessary, I don't think it would really harm anyone if that were changed.