### PR TITLE
Add links to solution repositories for Elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ in your favourite language.*
 
 *Solutions to AoC in Elixir.*
 
+* [sasa1977/aoc](https://github.com/sasa1977/aoc)
+* [bjorng/advent-of-code-2018](https://github.com/bjorng/advent-of-code-2018)
 * [axsuul/advent-of-code](https://github.com/axsuul/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/axsuul/advent-of-code.svg)
 * [codybartfast/aoc18](https://github.com/codybartfast/aoc18) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/codybartfast/aoc18.svg)
 * [kw7oe/advent-of-code-2018](https://github.com/kw7oe/advent-of-code-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/kw7oe/advent-of-code-2018.svg)


### PR DESCRIPTION
The repositories added in this commit are of [Sasa Juri](https://github.com/sasa1977) (author of [Elixir in Action](https://www.manning.com/books/elixir-in-action-second-edition)) and [Björn Gustavsson](https://github.com/bjorng) (creator of [Wings3d](https://github.com/bjorng/wings)). These repos contain the solutions to all 25 problems in elixir, whereas some of the repos linked to in the current readme dont have the solutions to all the problems.

Hence I have added these new links to the top of the list for Elixir solutions.