### PR TITLE
Added aoc-cli in the tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ in your favourite language.*
 * [Globals medals overview](http://www.maurits.vdschee.nl/scatterplot/medals.html) -- Alternative global leaderboard showing first, second and third places as gold, silver and bronze medals.
 * [Scatterplot of first 100](http://www.maurits.vdschee.nl/scatterplot/) -- Scatterplot of the time taken to solve the parts of each puzzle by the first 100 people that solved it.
 * [aocdl](https://github.com/GreenLightning/advent-of-code-downloader) -- Command-line utility that automatically downloads your personal input file while you read the puzzle description *(Go)*.
+* [aoc-cli](https://github.com/keirua/aoc-cli) -- Command-line utility that helps solve problems in ruby: it downloads your personal input file, creates the sample source files and benchmarks your solutions *(Ruby)*.
 
 ## Other Advent Calendars
 


### PR DESCRIPTION
Added [aoc-cli](https://github.com/keirua/aoc-cli).

aoc-cli is a command-line utility that helps solve problems in ruby: it downloads your personal input file, creates the sample source files and benchmarks your solutions, writen in ruby