### PR TITLE
Polyglot Split

### DIFF
--- a/2018.md
+++ b/2018.md
@@ -231,6 +231,7 @@ of Code event.
 
 * [jabbalaci/AdventOfCode2018](https://github.com/jabbalaci/AdventOfCode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/jabbalaci/AdventOfCode2018.svg)
 * [narimiran/AdventOfCode2018](https://github.com/narimiran/AdventOfCode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/narimiran/AdventOfCode2018.svg)
+* [pietroppeter/AdventOfCode2018](https://github.com/pietroppeter/AdventOfCode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/pietroppeter/AdventOfCode2018.svg)
 
 #### OCaml
 
@@ -258,7 +259,6 @@ of Code event.
 
 *Solutions to AoC in multiple languages.*
 
-* [pietroppeter/AdventOfCode2018](https://github.com/pietroppeter/AdventOfCode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/pietroppeter/AdventOfCode2018.svg)
 * [sebbecking/AoC-2018](https://github.com/sebbecking/AoC-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/sebbecking/AoC-2018.svg)
 * [stewartpark/aoc-2018](https://github.com/stewartpark/aoc-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/stewartpark/aoc-2018.svg)
 * [AlexAegis/advent-of-code](https://github.com/AlexAegis/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/AlexAegis/advent-of-code.svg)
@@ -317,6 +317,7 @@ of Code event.
 * [zenieldanaku/AdventOfCode](https://github.com/zenieldanaku/AdventOfCode) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/zenieldanaku/AdventOfCode.svg)
 * [FelipeCortez/advent-of-code](https://github.com/FelipeCortez/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/FelipeCortez/advent-of-code.svg)
 * [ephemient/aoc2018](https://github.com/ephemient/aoc2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/ephemient/aoc2018.svg)
+* [pietroppeter/AdventOfCode2018](https://github.com/pietroppeter/AdventOfCode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/pietroppeter/AdventOfCode2018.svg)
 
 #### Racket
 

--- a/2018.md
+++ b/2018.md
@@ -263,12 +263,6 @@ of Code event.
 
 * [bewuethr/advent-of-code](https://github.com/bewuethr/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/bewuethr/advent-of-code.svg)
 
-#### Polyglot
-
-*Solutions to AoC in multiple languages.*
-
-* [AlexAegis/advent-of-code](https://github.com/AlexAegis/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/AlexAegis/advent-of-code.svg)
-
 #### Pony
 
 *Solutions to AoC in Pony.*
@@ -388,6 +382,7 @@ of Code event.
 * [sebnow/adventofcode](https://github.com/sebnow/adventofcode) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/sebnow/adventofcode.svg)
 * [svisser/advent-of-code-2018](https://github.com/svisser/advent-of-code-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/svisser/advent-of-code-2018.svg)
 * [w4tson/advent-of-code-2018](https://github.com/w4tson/advent-of-code-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/w4tson/advent-of-code-2018.svg)
+* [AlexAegis/advent-of-code](https://github.com/AlexAegis/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/AlexAegis/advent-of-code.svg)
 
 #### Scala
 
@@ -415,6 +410,7 @@ of Code event.
 *Solutions to AoC in TypeScript.*
 
 * [MattiasBuelens/advent-of-code-2018](https://github.com/MattiasBuelens/advent-of-code-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/MattiasBuelens/advent-of-code-2018.svg)
+* [AlexAegis/advent-of-code](https://github.com/AlexAegis/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/AlexAegis/advent-of-code.svg)
 
 #### Zig
 

--- a/2018.md
+++ b/2018.md
@@ -259,7 +259,6 @@ of Code event.
 
 *Solutions to AoC in multiple languages.*
 
-* [sebbecking/AoC-2018](https://github.com/sebbecking/AoC-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/sebbecking/AoC-2018.svg)
 * [stewartpark/aoc-2018](https://github.com/stewartpark/aoc-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/stewartpark/aoc-2018.svg)
 * [AlexAegis/advent-of-code](https://github.com/AlexAegis/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/AlexAegis/advent-of-code.svg)
 

--- a/2018.md
+++ b/2018.md
@@ -67,6 +67,7 @@ of Code event.
 
 * [adventofcode-clojurians/adventofcode-clojurians](https://github.com/adventofcode-clojurians/adventofcode-clojurians) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/adventofcode-clojurians/adventofcode-clojurians.svg)
 * [borkdude/advent-of-cljc](https://github.com/borkdude/advent-of-cljc) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/borkdude/advent-of-cljc.svg)
+* [FelipeCortez/advent-of-code](https://github.com/FelipeCortez/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/FelipeCortez/advent-of-code.svg)
 
 #### Crystal
 
@@ -255,7 +256,6 @@ of Code event.
 
 *Solutions to AoC in multiple languages.*
 
-* [FelipeCortez/advent-of-code](https://github.com/FelipeCortez/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/FelipeCortez/advent-of-code.svg)
 * [ephemient/aoc2018](https://github.com/ephemient/aoc2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/ephemient/aoc2018.svg)
 * [pietroppeter/AdventOfCode2018](https://github.com/pietroppeter/AdventOfCode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/pietroppeter/AdventOfCode2018.svg)
 * [sebbecking/AoC-2018](https://github.com/sebbecking/AoC-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/sebbecking/AoC-2018.svg)
@@ -314,6 +314,7 @@ of Code event.
 * [speixoto/advent-of-code](https://github.com/speixoto/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/speixoto/advent-of-code.svg)
 * [blu3r4y/AdventOfCode2018](https://github.com/blu3r4y/AdventOfCode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/blu3r4y/AdventOfCode2018.svg)
 * [zenieldanaku/AdventOfCode](https://github.com/zenieldanaku/AdventOfCode) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/zenieldanaku/AdventOfCode.svg)
+* [FelipeCortez/advent-of-code](https://github.com/FelipeCortez/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/FelipeCortez/advent-of-code.svg)
 
 #### Racket
 

--- a/2018.md
+++ b/2018.md
@@ -14,6 +14,7 @@ of Code event.
 *Solutions to AoC in AWK.*
 
 * [phikal/aoc2018](https://github.com/phikal/aoc2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/phikal/aoc2018.svg)
+* [FelipeCortez/advent-of-code](https://github.com/FelipeCortez/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/FelipeCortez/advent-of-code.svg)
 
 #### Ada
 
@@ -61,6 +62,7 @@ of Code event.
 * [metinsuloglu/AdventofCode18](https://github.com/metinsuloglu/AdventofCode18) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/metinsuloglu/AdventofCode18.svg)
 * [paulfedorow/adventofcode](https://github.com/paulfedorow/adventofcode) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/paulfedorow/adventofcode.svg)
 * [voivoid/advent-of-code](https://github.com/voivoid/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/voivoid/advent-of-code.svg)
+* [FelipeCortez/advent-of-code](https://github.com/FelipeCortez/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/FelipeCortez/advent-of-code.svg)
 
 #### Clojure
 

--- a/2018.md
+++ b/2018.md
@@ -163,6 +163,7 @@ of Code event.
 * [nerdopoly/aoc-2018](https://github.com/nerdopoly/aoc-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/nerdopoly/aoc-2018.svg)
 * [nrdmn/adventofcode2018](https://github.com/nrdmn/adventofcode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/nrdmn/adventofcode2018.svg)
 * [tfausak/advent-of-code](https://github.com/tfausak/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/tfausak/advent-of-code.svg)
+* [ephemient/aoc2018](https://github.com/ephemient/aoc2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/ephemient/aoc2018.svg)
 
 #### Idris
 
@@ -222,6 +223,7 @@ of Code event.
 * [tginsberg/advent-2018-kotlin](https://github.com/tginsberg/advent-2018-kotlin) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/tginsberg/advent-2018-kotlin.svg)
 * [wakingrufus/advent-of-code-2018](https://github.com/wakingrufus/advent-of-code-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/wakingrufus/advent-of-code-2018.svg)
 * [0legg/adventofcode](https://github.com/0legg/adventofcode) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/0legg/adventofcode.svg)
+* [ephemient/aoc2018](https://github.com/ephemient/aoc2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/ephemient/aoc2018.svg)
 
 #### Nim
 
@@ -256,7 +258,6 @@ of Code event.
 
 *Solutions to AoC in multiple languages.*
 
-* [ephemient/aoc2018](https://github.com/ephemient/aoc2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/ephemient/aoc2018.svg)
 * [pietroppeter/AdventOfCode2018](https://github.com/pietroppeter/AdventOfCode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/pietroppeter/AdventOfCode2018.svg)
 * [sebbecking/AoC-2018](https://github.com/sebbecking/AoC-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/sebbecking/AoC-2018.svg)
 * [stewartpark/aoc-2018](https://github.com/stewartpark/aoc-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/stewartpark/aoc-2018.svg)
@@ -315,6 +316,7 @@ of Code event.
 * [blu3r4y/AdventOfCode2018](https://github.com/blu3r4y/AdventOfCode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/blu3r4y/AdventOfCode2018.svg)
 * [zenieldanaku/AdventOfCode](https://github.com/zenieldanaku/AdventOfCode) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/zenieldanaku/AdventOfCode.svg)
 * [FelipeCortez/advent-of-code](https://github.com/FelipeCortez/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/FelipeCortez/advent-of-code.svg)
+* [ephemient/aoc2018](https://github.com/ephemient/aoc2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/ephemient/aoc2018.svg)
 
 #### Racket
 

--- a/2018.md
+++ b/2018.md
@@ -26,6 +26,7 @@ of Code event.
 *Solutions to AoC in Bash.*
 
 * [tfla/aoc](https://github.com/tfla/aoc) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/tfla/aoc.svg)
+* [stewartpark/aoc-2018](https://github.com/stewartpark/aoc-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/stewartpark/aoc-2018.svg)
 
 #### C
 
@@ -171,6 +172,12 @@ of Code event.
 
 * [dmalikov/advent-of-shame-2018](https://github.com/dmalikov/advent-of-shame-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/dmalikov/advent-of-shame-2018.svg)
 
+#### Io
+
+*Solutions to AoC in Io.*
+
+* [stewartpark/aoc-2018](https://github.com/stewartpark/aoc-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/stewartpark/aoc-2018.svg)
+
 #### Java
 
 *Solutions to AoC in Java.*
@@ -208,6 +215,7 @@ of Code event.
 * [sguest/advent-of-code](https://github.com/sguest/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/sguest/advent-of-code.svg)
 * [spalberg/AdventOfCode](https://github.com/spalberg/AdventOfCode) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/spalberg/AdventOfCode.svg)
 * [tommmyy/advent-of-code](https://github.com/tommmyy/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/tommmyy/advent-of-code.svg)
+* [stewartpark/aoc-2018](https://github.com/stewartpark/aoc-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/stewartpark/aoc-2018.svg)
 
 #### Kotlin
 
@@ -259,7 +267,6 @@ of Code event.
 
 *Solutions to AoC in multiple languages.*
 
-* [stewartpark/aoc-2018](https://github.com/stewartpark/aoc-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/stewartpark/aoc-2018.svg)
 * [AlexAegis/advent-of-code](https://github.com/AlexAegis/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/AlexAegis/advent-of-code.svg)
 
 #### Pony

--- a/README.md
+++ b/README.md
@@ -200,12 +200,6 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 
 *Solutions to AoC in Perl.*
 
-#### Polyglot
-
-*Solutions to AoC in multiple languages.*
-
-* [AlexAegis/advent-of-code](https://github.com/AlexAegis/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/AlexAegis/advent-of-code.svg)
-
 #### Pony
 
 *Solutions to AoC in Pony.*
@@ -242,6 +236,8 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 
 *Solutions to AoC in Rust.*
 
+* [AlexAegis/advent-of-code](https://github.com/AlexAegis/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/AlexAegis/advent-of-code.svg)
+
 #### Scala
 
 *Solutions to AoC in Scala.*
@@ -255,6 +251,8 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 #### TypeScript
 
 *Solutions to AoC in TypeScript.*
+
+* [AlexAegis/advent-of-code](https://github.com/AlexAegis/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/AlexAegis/advent-of-code.svg)
 
 #### Zig
 


### PR DESCRIPTION
Went ahead and sorted each year's Polyglot repositories into multiple sections according to what I found in those repositories:

## 2019

1 added to TypeScript and Rust

## 2018

1 repo has been split into 4 parts
2 repo into 3
1 repo into 2
1 repo has been deleted as it's no longer available and the author has no public repositories.

For more information check the commit messages. Each repo's split has a separate commit.