### PR TITLE
Add IFinners' Advent of Code repository to README and 2018.md

### DIFF
--- a/2018.md
+++ b/2018.md
@@ -364,6 +364,7 @@ of Code] event.
 * [FelipeCortez/advent-of-code](https://github.com/FelipeCortez/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/FelipeCortez/advent-of-code.svg)
 * [ephemient/aoc2018](https://github.com/ephemient/aoc2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/ephemient/aoc2018.svg)
 * [pietroppeter/AdventOfCode2018](https://github.com/pietroppeter/AdventOfCode2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/pietroppeter/AdventOfCode2018.svg)
+* [IFinners/advent-of-code](https://github.com/IFinners/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/IFinners/advent-of-code.svg)
 
 #### Racket
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 * [PatMyron/advent-of-code](https://github.com/PatMyron/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/PatMyron/advent-of-code.svg)
 * [Dementophobia/advent-of-code-2019](https://github.com/Dementophobia/advent-of-code-2019) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/Dementophobia/advent-of-code-2019.svg)
 * [Levivig/AdventOfCode2019](https://github.com/Levivig/AdventOfCode2019) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/Levivig/AdventOfCode2019.svg)
+* [IFinners/advent-of-code](https://github.com/IFinners/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/IFinners/advent-of-code.svg)
 
 #### R
 


### PR DESCRIPTION
Adds a link to my repository under the Python section of both the README and 2018 files.