### PR TITLE
Adding mjpieters/adventofcode

### DIFF
--- a/2018.md
+++ b/2018.md
@@ -352,6 +352,7 @@ of Code] event.
 * [iBelieve/adventofcode](https://github.com/iBelieve/adventofcode) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/iBelieve/adventofcode.svg)
 * [j0057/aoc2018](https://github.com/j0057/aoc2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/j0057/aoc2018.svg)
 * [oskar404/aoc](https://github.com/oskar404/aoc) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/oskar404/aoc.svg)
+* [mjpieters/adventofcode](https://github.com/mjpieters/adventofcode) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/mjpieters/adventofcode.svg)
 * [racinmat/advent_of_code_2018](https://github.com/racinmat/advent_of_code_2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/racinmat/advent_of_code_2018.svg)
 * [rhbvkleef/aoc-2018](https://github.com/rhbvkleef/aoc-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/rhbvkleef/aoc-2018.svg)
 * [rossengeorgiev/adventofcode-2018](https://github.com/rossengeorgiev/adventofcode-2018) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/rossengeorgiev/adventofcode-2018.svg)

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 * [mebeim/aoc](https://github.com/mebeim/aoc) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/mebeim/aoc.svg)
 * [metzbernhard/aoc2019](https://github.com/metzbernhard/aoc2019) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/metzbernhard/aoc2019.svg)
 * [mevdschee/AdventOfCode2019](https://github.com/mevdschee/AdventOfCode2019) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/mevdschee/AdventOfCode2019.svg)
+* [mjpieters/adventofcode](https://github.com/mjpieters/adventofcode) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/mjpieters/adventofcode.svg)
 * [mpindaro/advent-of-code-2019](https://bitbucket.org/mpindaro/advent-of-code-2019/src/master/)
 * [polhec42/AOC](https://github.com/polhec42/AOC) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/polhec42/AOC.svg)
 * [r0f1/adventofcode2019](https://github.com/r0f1/adventofcode2019) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/r0f1/adventofcode2019.svg)


### PR DESCRIPTION
Python solutions with expositions, in notebooks, covering 2017, 2018 and 2019-in-progress