### PR TITLE
Add link to aocleaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ in your favourite language.*
 * [aocdl](https://github.com/GreenLightning/advent-of-code-downloader) -- Command-line utility that automatically downloads your personal input file while you read the puzzle description *(Go)*.
 * [aoc-cli](https://github.com/keirua/aoc-cli) -- Command-line utility that helps solve problems in ruby: it downloads your personal input file, creates the sample source files and benchmarks your solutions *(Ruby)*.
 * [AoCHelper](https://github.com/eduherminio/AoCHelper) -- NuGet library that simplifies puzzle solving and provides benchmarking *(.NET)*.
+* [aocleaderboard](https://github.com/scarvalhojr/aocleaderboard) -- get over the 200-member limit for private leaderboards and combine multiple leaderboards in a single page with recalculated scores.
 
 ## Other Advent Calendars
 


### PR DESCRIPTION
aocleaderboard is a web app written in Rust and powered by Rocket.rs to combine multiple private leaderboards