### PR TITLE
feature: add my JS repo to 2020 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 *Solutions to AoC in JavaScript.*
 
 * [mariotacke/advent-of-code-2020](https://github.com/mariotacke/advent-of-code-2020) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2020--11--26-brightgreen)
+* [adriennetacke/advent-of-code-2020](https://github.com/adriennetacke/advent-of-code-2020)
 
 #### Julia
 


### PR DESCRIPTION
I added a link to my repo for Advent of Code 2020