### PR TITLE
Add aoc-ranking to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ in your favourite language.*
 * [aocleaderboard](https://github.com/scarvalhojr/aocleaderboard) -- get over the 200-member limit for private leaderboards and combine multiple leaderboards in a single page with recalculated scores.
 * [advent-of-code-api](https://hackage.haskell.org/package/advent-of-code-api) -- Haskell library for querying AOC prompts, inputs, and leaderboards *(Haskell)*
 * [advent-of-code-orcr](https://github.com/mstksg/advent-of-code-ocr#readme) -- Command line utility and Haskell library for parsing AoC ascii art words
+* [aoc-ranking](https://github.com/freedomofkeima/aoc-ranking) -- Show all non-zero score AoC participants in one, global scoreboard. *(Python)*
 
 ## Other Advent Calendars
 


### PR DESCRIPTION
Hi! Recently I created a simple tool on https://freedomofkeima.github.io/aoc-ranking/, which will show all non-zero score AoC participants in one, global scoreboard. This data is cached and will be updated daily during AoC period.

![](https://raw.githubusercontent.com/freedomofkeima/aoc-ranking/master/images/screenshot.png)

Thank you!