### PR TITLE
Fix badge update colors

### DIFF
--- a/.github/actions/update-badge/endpoint.js
+++ b/.github/actions/update-badge/endpoint.js
@@ -45,11 +45,11 @@ function colorScale(steps, colors, reversed) {
   }
 
   const defaultColors = {
-    1: ['red', 'brightgreen'],
-    2: ['red', 'yellow', 'brightgreen'],
-    3: ['red', 'yellow', 'green', 'brightgreen'],
-    4: ['red', 'yellow', 'yellowgreen', 'green', 'brightgreen'],
-    5: ['red', 'orange', 'yellow', 'yellowgreen', 'green', 'brightgreen'],
+    1: ['brightgreen', 'red'],
+    2: ['brightgreen', 'yellow', 'red'],
+    3: ['brightgreen', 'green', 'yellow', 'red'],
+    4: ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red'],
+    5: ['brightgreen', 'green', 'yellowgreen', 'yellow', 'orange', 'red']
   }
 
   if (typeof colors === 'undefined') {
@@ -71,20 +71,20 @@ function colorScale(steps, colors, reversed) {
   }
 
   return value => {
-    const stepIndex = steps.findIndex(step => value < step)
+    const stepIndex = steps.findIndex(step => value >= step)
 
-    // For the final step, stepIndex is -1, so in all cases this expression
-    // works swimmingly.
+    // For any value above the final step, stepIndex is -1, so in all cases this
+    // expression works swimmingly.
     return colors.slice(stepIndex)[0]
   }
 }
 
 function age(date) {
   const now = moment()
-  const dec1st = moment([now.year(), 11, 1])
-  if (now.diff(dec1st) < 0) dec1st.add(-1, 'y')
+  const then = moment(date)
+  if (now.diff(date) < 0) date.add(-1, 'y')
 
-  const daysElapsed = moment(date).diff(moment(dec1st), 'days') + 1
-  const colorByAge = colorScale([0, 5, 10, 20, 25], undefined, false)
+  const daysElapsed = now.diff(moment(date), 'days')
+  const colorByAge = colorScale([1, 5, 10, 20, 25], undefined, false)
   return colorByAge(daysElapsed)
 }


### PR DESCRIPTION
This fixes the color of badges in the README wen updating through GitHub Actions.

The original code was looking at the number of days from Dec 1st and then using it as the value to look for in the `steps` array which defines the steps for each color, but the calculations were off. The current code simply checks for the number of days elapsed since the last commit, regardless of the distance from Dec 1st, since that is eventually all we care about (right?).

The current steps apply these colors:

- Last commit <= 1d ago: `brightgreen`
- Last commit <= 5d ago: `green`
- Last commit <= 10d ago: `yellowgreen`
- Last commit <= 20d ago: `yellow`
- Last commit <= 25d ago: `orange`
- Last commit > 25d ago: `red`

I tested this both locally and on my fork and it seemed to work fine. Let me know if anything needs change.