### PR TITLE
Restore thlacroix and orfeasa's repos for Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 * [nlowe/aoc2020](https://github.com/nlowe/aoc2020) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2020--12--17-brightgreen)
 * [sshilin/aoc2020](https://github.com/sshilin/aoc2020) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2020--12--23-brightgreen)
 * [Alex-Wauters/advent-go-2020](https://github.com/Alex-Wauters/advent-go-2020) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2020--12--25-brightgreen)
+* [thlacroix/goadvent]
+* [orfeasa/advent-of-code-2020]
 
 #### Groovy
 


### PR DESCRIPTION
The repo added by me and @thlacroix were removed when this PR was merged: https://github.com/Bogdanp/awesome-advent-of-code/commit/84f62b24f9e13ef3556aeaa4c40839be9a63dfd8

This PR restores them