### PR TITLE
Remove `codemicro/adventOfCode` AoC template

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ in your favourite language.*
 * [gobanos/cargo-aoc](https://github.com/gobanos/cargo-aoc) *(Rust)*
 * [nickyvanurk/advent-of-code-rust-template](https://github.com/nickyvanurk/advent-of-code-rust-template) *(Rust)*
 * [hughjdavey/aoc-kotlin-starter](https://github.com/hughjdavey/aoc-kotlin-starter) *(Kotlin)*
-* [codemicro/adventOfCode](https://github.com/codemicro/adventOfCode/tree/master/template) *(Go, Python)*
 * [kindermoumoute/adventofcode](https://github.com/kindermoumoute/adventofcode/tree/master/template) *(Go)*
 * [staylorwr/elixir_aoc](https://github.com/staylorwr/elixir_aoc) *(Elixir)*
 * [mhanberg/advent-of-code-elixir-starter](https://github.com/mhanberg/advent-of-code-elixir-starter) *(Elixir)*


### PR DESCRIPTION
This has since been removed and replaced with something else that's not documented well enough to be put on this list.