### PR TITLE
add eggnog tool to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ in your favourite language.*
 * [aoc-cli](https://github.com/scarvalhojr/aoc-cli) -- Read puzzle descriptions, download input, and submit answers from the comfort of your terminal. *(Rust)*
 * [adventofcode-badge](https://github.com/stackcats/adventofcode-badge) -- An interface over Shields.io to facilitate the creation of badges from Advent of Code.
 * [@aocjs/cli](https://github.com/aocjs/cli) -- Package for executing solutions with hot reload and data fetching *(JavaScript, TypeScript)*
+* [eggnog](https://github.com/breakthatbass/eggnog) -- CLI for getting input, directions (with nice colors!), and submitting answers. Caches absolutely everything. *(C)*
 
 ## Other Advent Calendars
 


### PR DESCRIPTION
Added my AoC cli tool (eggnog) to the readme under the Tools & Utilities section