### PR TITLE
feat: adds richardneililagan/adventofcode-2021 to 2021 Rust repo catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 
 *Solutions to AoC in Rust.*
 
+* [richardneililagan/adventofcode-2021]
+
 
 #### Smalltalk
 


### PR DESCRIPTION
Adds [richardneililagan/adventofcode-2021][aoc2021] (my own) to the list of Rust solution repos.

Didn't put in the badge (as it wasn't mentioned in `CONTRIBUTING`) — I'm assuming that's pulled by a build step? :)

[aoc2021]: https://github.com/richardneililagan/adventofcode-2021