### PR TITLE
ensure badges show green if updated same day

### DIFF
--- a/.github/actions/update-badge/endpoint.js
+++ b/.github/actions/update-badge/endpoint.js
@@ -85,6 +85,6 @@ function age(date) {
   if (now.diff(date) < 0) date.add(-1, 'y')
 
   const daysElapsed = now.diff(moment(date), 'days')
-  const colorByAge = colorScale([1, 5, 10, 20, 25], undefined, false)
+  const colorByAge = colorScale([0, 5, 10, 20, 25], undefined, false)
   return colorByAge(daysElapsed)
 }


### PR DESCRIPTION
Badges are showing red for very up-to-date branches, which I don't _think_ is the goal. (The comment on line 76 suggests this is what's supposed to happen for very outdated repos, not very fresh ones.)

![Screen Shot 2021-12-03 at 3 06 04 AM](https://user-images.githubusercontent.com/401264/144567451-3afd7467-64ab-4e4b-b240-d006629b9904.png)
