### PR TITLE
Add shadow578/AdventOfCode2021 and shadow578/advent-of-pain-2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 
 *Solutions to AoC in Assembly.*
 
+* [shadow578/advent-of-pain-2021]
+
 #### AWK
 
 *Solutions to AoC in AWK.*

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 * [thejan14/adventofcode2021](https://github.com/thejan14/adventofcode2021) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2021--12--12-brightgreen)
 * [warriordog/advent-of-code-2021](https://github.com/warriordog/advent-of-code-2021) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2021--12--11-brightgreen)
 * [xhayper/advent-of-code](https://github.com/xhayper/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2021--12--08-brightgreen)
+* [shadow578/AdventOfCode2021]
 
 #### jq
 


### PR DESCRIPTION
This PR adds my personal repos for Advent of Code 2021.

shadow578/advent-of-pain-2021 is a mixed language repo, so I don't know if i put it into the correct section. 
If i did not, i'm also ok to remove it.



