### PR TITLE
add `advent-of-code-rust` template

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ in your favourite language.*
 * [dave-burke/advent-of-code-java-starter](https://github.com/dave-burke/advent-of-code-java-starter) *(Java)*
 * [gobanos/cargo-aoc](https://github.com/gobanos/cargo-aoc) *(Rust)*
 * [nickyvanurk/advent-of-code-rust-template](https://github.com/nickyvanurk/advent-of-code-rust-template) *(Rust)*
+* [fspoettel/advent-of-code-rust](https://github.com/fspoettel/advent-of-code-rust) *(Rust)*
 * [hughjdavey/aoc-kotlin-starter](https://github.com/hughjdavey/aoc-kotlin-starter) *(Kotlin)*
 * [Jadarma/advent-of-code-kotlin](https://github.com/Jadarma/advent-of-code-kotlin/tree/clean-template) *(Kotlin)*
 * [kindermoumoute/adventofcode](https://github.com/kindermoumoute/adventofcode/tree/master/template) *(Go)*


### PR DESCRIPTION
This PR adds [my rust template](https://github.com/fspoettel/advent-of-code-rust) to the project template section.

Feature-wise, it sits between the two existing projects with the goal of being welcoming to people new to the language. I hope it's a worthy addition to the project.

Either way, thank you for maintaining this repo!