### PR TITLE
Add MKolman/advent-of-code to Rust repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ in your favourite language.*
   * [Firefox extension "Advent of Code Charts"](https://addons.mozilla.org/en-US/firefox/addon/advent-of-code-charts/)
 * [Globals medals overview](http://www.maurits.vdschee.nl/scatterplot/medals.html) -- Alternative global leaderboard showing first, second and third places as gold, silver and bronze medals.
 * [Scatterplot of first 100](http://www.maurits.vdschee.nl/scatterplot/) -- Scatterplot of the time taken to solve the parts of each puzzle by the first 100 people that solved it.
+* [Private Leaderboard Visualiser](https://aoc.kolman.si/vis/) -- Given a JSON of your private leaderboard data this website will show you graphs of how long each member took to solve parts 1 and 2 of each day. 
 * [aocdl](https://github.com/GreenLightning/advent-of-code-downloader) -- Command-line utility that automatically downloads your personal input file while you read the puzzle description *(Go)*.
 * [aocinput](https://github.com/dds/aoc2020/blob/main/cmd/aocinput/aocinput.go) -- CLI for getting inputs. Clipboard support. Polite to AoC. Nice help and options. *(Go)*
 * [aoc_rb](https://github.com/pacso/aoc_rb) -- A Ruby gem that generates an empty AoC project, and provides command-line tools for fetching input and submitting solutions  *(Ruby)*
@@ -725,6 +726,7 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 * [zargony/advent-of-code-2022](https://github.com/zargony/advent-of-code-2022) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2022--12--14-brightgreen)
 * [zsacul/AdventOfCode2022](https://github.com/zsacul/AdventOfCode2022) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2022--12--17-brightgreen)
 * [MariaChrysafis/2022-Advent-of-Code](https://github.com/MariaChrysafis/2022-Advent-of-Code) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2022--12--15-brightgreen)
+* [MKolman/advent-of-code]
 
 #### Smalltalk
 


### PR DESCRIPTION
In addition to my solutions in Rust I also added a link to a website I made showing graphs of solve time for private leaderboards:
![time_to_solve_p1_p2](https://user-images.githubusercontent.com/1653035/208285631-cfd2b9dd-e59d-4f53-841f-fe584ddab393.png)
![time_to_stars](https://user-images.githubusercontent.com/1653035/208285634-803a9b38-83d6-4a74-8571-6853df43650f.png)
