### PR TITLE
add my solutions and template

### DIFF
--- a/2020.md
+++ b/2020.md
@@ -573,6 +573,7 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 * [VasileiosGeladaris/AdventOfCode2020](https://github.com/VasileiosGeladaris/AdventOfCode2020) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2020--12--10-brightgreen)
 * [vss2sn/advent_of_code](https://github.com/vss2sn/advent_of_code)
 * [wysockipiotr/aoc](https://github.com/wysockipiotr/aoc) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2020--12--18-brightgreen)
+* [xavdid/advent-of-code](https://github.com/xavdid/advent-of-code/tree/main/solutions/2020) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--09--30-brightgreen)
 * [yeurch/advent-of-code](https://github.com/yeurch/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2020--12--27-brightgreen)
 * [yspreen/adventofcode](https://github.com/yspreen/adventofcode) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2021--10--12-brightgreen)
 * [yufengg/adventofcode](https://github.com/yufengg/adventofcode) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2020--12--21-brightgreen)

--- a/2021.md
+++ b/2021.md
@@ -623,6 +623,7 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 * [zedrdave/advent_of_code](https://github.com/zedrdave/advent_of_code) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2021--12--23-brightgreen)
 * [TurtleSmoke/Advent-of-Code](https://github.com/TurtleSmoke/Advent-of-Code)
 * [vil02/adv_2021](https://github.com/vil02/adv_2021)
+* [xavdid/advent-of-code](https://github.com/xavdid/advent-of-code/tree/main/solutions/2021) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--09--30-brightgreen)
 
 #### R
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ in your favourite language.*
 * [tomfran/advent-of-code-setup](https://github.com/tomfran/advent-of-code-setup) *(Python)*
 * [wizardofzos/aoc2021](https://github.com/wizardofzos/aoc2021) *(Flask-API, Python running REXX on Mainframes)*
 * [fangyi-zhou/advent-of-code-ocaml-starter](https://github.com/fangyi-zhou/advent-of-code-ocaml-starter) *(OCaml)*
+* [xavdid/advent-of-code-python-template](https://github.com/xavdid/advent-of-code-python-template) *(Python)*
 
 ## Tools and Utilities
 
@@ -668,6 +669,7 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 * [zu-se/AdventOfCode2022](https://github.com/zu-se/AdventOfCode2022) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--01--05-brightgreen)
 * [GuglielmoCerri/Advent-of-Code](https://github.com/GuglielmoCerri/Advent-of-Code) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--08--09-brightgreen)
 * [vil02/adv_2022](https://github.com/vil02/adv_2022) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--09--22-brightgreen)
+* [xavdid/advent-of-code](https://github.com/xavdid/advent-of-code/tree/main/solutions/2022) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--09--30-brightgreen)
 
 #### R
 


### PR DESCRIPTION
I've got a single monorepo that has all of my solutions: https://github.com/xavdid/advent-of-code 

So for individual years, I linked that subfolder. I can also link everything to the root of the repo, if you prefer.

I've also got a template repo, which I linked: https://github.com/xavdid/advent-of-code-python-template

Thanks!