### PR TITLE
Updated Readme: removed inaccessible repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,6 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 * [lionel-nj/advent-of-code-2022](https://github.com/lionel-nj/advent-of-code-2022) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2022--12--11-brightgreen)
 * [nsirons/programming-puzzles](https://github.com/nsirons/programming-puzzles) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--01--06-brightgreen)
 * [rafa-o/advent-of-code-2022](https://github.com/rafa-o/advent-of-code-2022) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2022--12--21-brightgreen)
-* [sinansonmez/AOC-2022](https://github.com/sinansonmez/AOC-2022) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2022--12--06-brightgreen)
 
 #### LDPL
 


### PR DESCRIPTION
The AOC repository [sinansonmez/AOC-2022](https://github.com/sinansonmez/AOC-2022) can not be accessed anymore so I would propose to remove it 😕