### PR TITLE
Add solutions for nlowe for 2018, 2019, 2021, 2022, and 2023

### DIFF
--- a/2018.md
+++ b/2018.md
@@ -202,6 +202,7 @@ of Code] event.
 * [GreenLightning/aoc18](https://github.com/GreenLightning/aoc18) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/GreenLightning/aoc18.svg)
 * [mnml/aoc](https://github.com/mnml/aoc) ![Last Commit on GitHub](https://img.shields.io/github/last-commit/mnml/aoc.svg)
 * [sivertjoe/Advent-of-Code](https://github.com/sivertjoe/Advent-of-Code)
+* [nlowe/aoc2018](https://github.com/nlowe/aoc2018)
 
 #### Groovy
 

--- a/2019.md
+++ b/2019.md
@@ -210,6 +210,7 @@ Read [CONTRIBUTING.md](/CONTRIBUTING.md) to learn how to add your own repos.
 * [mightymatth/advent-of-code-2019](https://github.com/mightymatth/advent-of-code-2019) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2020--01--02-brightgreen)
 * [stevotvr/adventofcode2019](https://github.com/stevotvr/adventofcode2019) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2019--12--29-brightgreen)
 * [mnml/aoc](https://github.com/mnml/aoc) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2019--12--30-brightgreen)
+* [nlowe/aoc2019](https://github.com/nlowe/aoc2019)
 
 #### Groovy
 

--- a/2021.md
+++ b/2021.md
@@ -307,7 +307,8 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 * [stscoundrel/advent-of-code-2021](https://github.com/stscoundrel/advent-of-code-2021) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2021--12--30-brightgreen)
 * [shpikat/advent-of-code-2021](https://github.com/shpikat/advent-of-code-2021) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2022--10--03-brightgreen)
 * [AndrewSav/adventofcode2021-golang](https://github.com/AndrewSav/adventofcode2021-golang)
-# [alokmenghrajani/adventofcode2021](https://github.com/alokmenghrajani/adventofcode2021)
+* [alokmenghrajani/adventofcode2021](https://github.com/alokmenghrajani/adventofcode2021)
+* [nlowe/aoc2021](https://github.com/nlowe/aoc2021)
 
 #### Groovy
 

--- a/2022.md
+++ b/2022.md
@@ -307,6 +307,7 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 * [sumnerevans/advent-of-code](https://github.com/sumnerevans/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--05--22-brightgreen)
 * [tsenart/advent](https://github.com/tsenart/advent) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2022--12--23-brightgreen)
 * [zbyju/advent-of-code](https://github.com/zbyju/advent-of-code) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--05--31-brightgreen)
+* [nlowe/aoc2022](https://github.com/nlowe/aoc2022)
 
 #### Groovy
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 
 *Solutions to AoC in Go.*
 
+* [nlowe/aoc2023]
+
 #### Groovy
 
 *Solutions to AoC in Groovy.*


### PR DESCRIPTION
I had solution links for 2020 but not any of the other years!