### PR TITLE
add erdos/advent-of-code for clojure solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 *Solutions to AoC in Clojure.*
 
 * [slotThe/advent](https://github.com/slotThe/advent) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--12--11-brightgreen)
+* [erdos/advent-of-code](https://github.com/erdos/advent-of-code)  ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2023--12--12-brightgreen)
 
 #### Common Lisp
 


### PR DESCRIPTION
Addig repo https://github.com/erdos/advent-of-code to the list of Clojure langauge solutions. 