### PR TITLE
update-badge: tune request chunking

### DIFF
--- a/.github/actions/update-badge/updateRepos.js
+++ b/.github/actions/update-badge/updateRepos.js
@@ -2,11 +2,11 @@ const core = require('@actions/core')
 const { setTimeout: sleep } = require('timers/promises')
 
 // limit size of each request to avoid getting timed out
-const chunkSize = 200
+const chunkSize = 100
 
 // limit request rate to one chunk per requestWaitTime (seconds) to avoid exceeding secondary rate limits
 // https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api#secondary-rate-limits
-const requestWaitTime = 20
+const requestWaitTime = 5
 let lastRequestTime = 0
 
 // retry the request if it fails, throw if request fails requestRetries times


### PR DESCRIPTION
In reference to issue #1869, I've tuned the request chunking parameters to reduce the request body size to avoid letting the GitHub GraphQL API time out. This was quite effective and allowed room to also reduce the wait time between requests.

In `updateRepos.js`:
- `chunkSize` 200 -> 100 (repos per request)
- `requestWaitTime` 20 -> 5 (seconds)

Testing on a fork this reduced the action time from 10-15 minutes down to ~3 minutes with zero `HttpError: Unknown error:` errors.