### PR TITLE
add vil02/adv_2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 * [ndunnett/aoc](https://github.com/ndunnett/aoc) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2024--11--30-brightgreen)
 * [maread99/aoc](https://github.com/maread99/aoc) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2024--11--28-brightgreen)
 * [r0f1/adventofcode2024](https://github.com/r0f1/adventofcode2024) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2024--11--29-brightgreen)
+* [vil02/adv_2024]
 
 #### R
 


### PR DESCRIPTION
Similarly as in #1588, #1589 and #1630, I would like to add [my python solutions of AoC2024](https://github.com/vil02/adv_2024).