### PR TITLE
fix: Moves lua template to the correct location

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ in your favourite language.*
 * [JohnBjrk/adglent](https://github.com/JohnBjrk/adglent) *Gleam*
 * [pgebert/advent-of-code-kotlin-template](https://github.com/pgebert/advent-of-code-kotlin-template) *(Kotlin)*
 * [jromero132/advent-of-code](https://github.com/jromero132/advent-of-code) *(Python)*
-* [lcpichette/aoc-lua-template](https://github.com/lcpichette/aoc-lua-template)
+* [lcpichette/aoc-lua-template](https://github.com/lcpichette/aoc-lua-template) *(Lua)*
 
 ## Tools and Utilities
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ in your favourite language.*
 * [JohnBjrk/adglent](https://github.com/JohnBjrk/adglent) *Gleam*
 * [pgebert/advent-of-code-kotlin-template](https://github.com/pgebert/advent-of-code-kotlin-template) *(Kotlin)*
 * [jromero132/advent-of-code](https://github.com/jromero132/advent-of-code) *(Python)*
+* [lcpichette/aoc-lua-template](https://github.com/lcpichette/aoc-lua-template)
 
 ## Tools and Utilities
 
@@ -422,8 +423,6 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 #### Lua
 
 *Solutions to AoC in Lua.*
-
-* [lcpichette/aoc-lua-template](https://github.com/lcpichette/aoc-lua-template) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2024--12--01-brightgreen)
 
 #### M4
 


### PR DESCRIPTION
I had mistakenly put my lua template in the solutions section when it should have been put with the templates.

[Related PR](https://github.com/Bogdanp/awesome-advent-of-code/pull/1891). 

I apologize for making you review the same thing twice bogdanp! I appreciate the time you put in to maintaining this resource.