### PR TITLE
Add thermoweb java template

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ in your favourite language.*
 * [caderek/aoc-starter-ts](https://github.com/caderek/aoc-starter-ts) *(TypeScript)*
 * [dave-burke/advent-of-code-java-starter](https://github.com/dave-burke/advent-of-code-java-starter) *(Java)*
 * [Viinyard/adventofcode-template](https://github.com/Viinyard/adventofcode-template) *(Java)*
+* [thermoweb/aoc-java-template](https://github.com/thermoweb/aoc-java-template) *(Java)*
 * [devries/aoc_template](https://github.com/devries/aoc_template) *(Go)*
 * [dvoiejanovic/advent-of-ruby](https://github.com/dvoiejanovic/advent-of-ruby) *(Ruby)*
 * [eduherminio/AdventOfCode.MultiYearTemplate](https://github.com/eduherminio/AdventOfCode.MultiYearTemplate) *(C#)*


### PR DESCRIPTION
Adds a minimal Java template created by @thermoweb (with the authors permission https://github.com/thermoweb/aoc-java-template/issues/1), which supports convenient commands for:
- generating skeleton for a day
- downloading puzzle input for a day and/or year
- running solution for a day with the puzzle input