### PR TITLE
Add repo piscilus/aoc24 to list of solutions in C for 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 * [StynH/Advent-Of-Code2024-in-C-23](https://github.com/StynH/Advent-Of-Code2024-in-C-23) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2024--12--05-brightgreen)
 * [alexlnkp/aoc](https://github.com/alexlnkp/aoc) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2024--12--09-brightgreen)
 * [happycoder74/adventofcode](https://github.com/happycoder74/adventofcode) ![Last Commit on GitHub](https://img.shields.io/badge/last%20commit-2024--12--13-brightgreen)
+* [piscilus/aoc24](https://github.com/piscilus/aoc24)
 
 #### C#
 


### PR DESCRIPTION
I got deleted from the list by accident?
See commit c21fb30fe61852d9078c9cc4716b1ce99aafd433