### PR TITLE
feat: add .gitattributes file to detect Markdown files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.md linguist-detectable=true
+*.md linguist-language=Markdown
+*.md linguist-documentation=false


### PR DESCRIPTION
### Pull Request Notes

Added a `.gitattributes` file to configure Markdown file recognition in the repository. This ensures Markdown files are counted in the repository's language statistics, setting the primary language to Markdown. While it doesn't affect functionality, it's a nice touch for better presentation.