### PR TITLE
Add x64 nasm assembly repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md) to learn how to add your own re
 #### Assembly
 
 *Solutions to AoC in Assembly.*
+* [hachem/aoc](https://git.hachem.wtf/aoc.git)
 
 #### AWK
 


### PR DESCRIPTION
Adding [my own solutions](https://git.hachem.wtf/aoc.git/) to the 2025 advent of code in x64 nasm assembly. The git repo is hosted on my private git server.